### PR TITLE
Laravel mixにCSSフレームワークTailwindcssの追加（２）

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -552,15 +552,8 @@ Ensure the default browser behavior of the `hidden` attribute.
   font-size: 1.125rem;
   line-height: 1.75rem;
 }
-.text-3xl {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
-}
 .font-semibold {
   font-weight: 600;
-}
-.font-bold {
-  font-weight: 700;
 }
 .leading-7 {
   line-height: 1.75rem;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   content: [
+    './storage/framework/views/*.php',
     "./resources/**/*.blade.php",
     "./resources/**/*.js",
     "./resources/**/*.vue",


### PR DESCRIPTION
# やったこと

* Laravel mixにCSSフレームワークTailwindcssの追加
* 設定値が漏れていたので追加

# やらないこと

* 特になし

# できるようになること

* 実装でTailwindcssが利用可能になる

# できなくなること

* 特になし

# 動作確認

* yarn実行後、クラスを定義しスタイルが適用されることを確認済

# その他

* [Laravel 8.x アセットのコンパイル（Mix）](https://readouble.com/laravel/8.x/ja/mix.html#tailwindcss)
